### PR TITLE
Implement generate command

### DIFF
--- a/clo.json
+++ b/clo.json
@@ -36,6 +36,7 @@
       "hint": "generate clo.json",
       "desc": "generate clo.json with input data",
       "arguments": [
+        "app",
         "command",
         "argument",
         "flag"
@@ -53,23 +54,26 @@
       "required": true
     },
     {
+      "token": "app",
+      "hint": "application name"
+    },
+    {
       "token": "command",
-      "abbr": "c",
+      "abbr": "cmd",
       "hint": "clo.json command",
       "desc": "clo.json command to add to the definitions",
-      "required": true,
       "multiple": true
     },
     {
       "token": "argument",
-      "abbr": "a",
+      "abbr": "arg",
       "hint": "clo.json argument",
-      "desc": "clo.json argument to add to the definitions",
+      "desc": "clo.json argument to add to the definitions. Prefix with _ for Def, * for Req (in that order), suffix with ... for Mult",
       "multiple": true
     },
     {
       "token": "flag",
-      "abbr": "f",
+      "abbr": "flg",
       "hint": "clo.json flag",
       "desc": "clo.json flag to add to the definitions",
       "multiple": true

--- a/clo.json
+++ b/clo.json
@@ -29,6 +29,17 @@
           "desc": "verify provided file for common errors and display report"
         }
       ]
+    },
+    {
+      "token": "generate",
+      "abbr": "gn",
+      "hint": "generate clo.json",
+      "desc": "generate clo.json with input data",
+      "arguments": [
+        "command",
+        "argument",
+        "flag"
+      ]
     }
   ],
   "arguments": [
@@ -40,6 +51,28 @@
       "env": true,
       "default": true,
       "required": true
+    },
+    {
+      "token": "command",
+      "abbr": "c",
+      "hint": "clo.json command",
+      "desc": "clo.json command to add to the definitions",
+      "required": true,
+      "multiple": true
+    },
+    {
+      "token": "argument",
+      "abbr": "a",
+      "hint": "clo.json argument",
+      "desc": "clo.json argument to add to the definitions",
+      "multiple": true
+    },
+    {
+      "token": "flag",
+      "abbr": "f",
+      "hint": "clo.json flag",
+      "desc": "clo.json flag to add to the definitions",
+      "multiple": true
     }
   ]
 }

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -1,0 +1,11 @@
+package cmd
+
+import "fmt"
+
+func Generate(commands, arguments, flags []string) error {
+	fmt.Println("generate")
+	fmt.Println("commands:", commands)
+	fmt.Println("arguments:", arguments)
+	fmt.Println("flags:", flags)
+	return nil
+}

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -1,11 +1,20 @@
 package cmd
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/boggydigital/clo/internal"
+)
 
-func Generate(commands, arguments, flags []string) error {
-	fmt.Println("generate")
-	fmt.Println("commands:", commands)
-	fmt.Println("arguments:", arguments)
-	fmt.Println("flags:", flags)
+func Generate(app string, commands, arguments, flags []string) error {
+	defs := internal.GenDefinitions(app, commands, arguments, flags)
+
+	bytes, err := json.Marshal(defs)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(bytes))
+
 	return nil
 }

--- a/cmd/route.go
+++ b/cmd/route.go
@@ -4,15 +4,20 @@ import (
 	"github.com/boggydigital/clo"
 )
 
-func Dispatch(request *clo.Request) error {
-	if request == nil {
+func Dispatch(req *clo.Request) error {
+	if req == nil {
 		return clo.Route(nil)
 	}
-	verbose := request.GetFlag("verbose")
-	switch request.Command {
+	verbose := req.GetFlag("verbose")
+	switch req.Command {
 	case "verify":
-		return Verify(request.GetValue("path"), verbose)
+		return Verify(req.GetValue("path"), verbose)
+	case "generate":
+		return Generate(
+			req.GetValues("command"),
+			req.GetValues("argument"),
+			req.GetValues("flag"))
 	default:
-		return clo.Route(request)
+		return clo.Route(req)
 	}
 }

--- a/cmd/route.go
+++ b/cmd/route.go
@@ -14,6 +14,7 @@ func Dispatch(req *clo.Request) error {
 		return Verify(req.GetValue("path"), verbose)
 	case "generate":
 		return Generate(
+			req.GetValue("app"),
 			req.GetValues("command"),
 			req.GetValues("argument"),
 			req.GetValues("flag"))

--- a/internal/generate.go
+++ b/internal/generate.go
@@ -1,0 +1,84 @@
+package internal
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	requiredPrefix = "*"
+	defaultPrefix  = "_"
+	multipleSuffix = "..."
+)
+
+func GenDefinitions(app string, commands, arguments, flags []string) *Definitions {
+	defs := &Definitions{
+		Version:   1,
+		EnvPrefix: strings.ToUpper(app),
+		App:       app,
+	}
+
+	if app != "" {
+		defs.Hint = fmt.Sprintf("%s hint", app)
+		defs.Desc = fmt.Sprintf("%s description", app)
+	}
+
+	for _, c := range commands {
+		defs.Commands = append(defs.Commands, *genCommand(c))
+	}
+	for _, a := range arguments {
+		defs.Arguments = append(defs.Arguments, *genArgument(a))
+	}
+	for _, f := range flags {
+		defs.Flags = append(defs.Flags, *genFlag(f))
+	}
+	return defs
+}
+
+func genCommand(cmd string) *CommandDefinition {
+	return &CommandDefinition{
+		CommonDefinition: CommonDefinition{
+			Token: cmd,
+			Hint:  fmt.Sprintf("%s hint", cmd),
+			Desc:  fmt.Sprintf("%s description", cmd),
+		},
+		Arguments: []string{},
+	}
+}
+
+func genArgument(arg string) *ArgumentDefinition {
+	ad := &ArgumentDefinition{
+		CommonDefinition: CommonDefinition{},
+	}
+
+	if strings.HasPrefix(arg, defaultPrefix) {
+		ad.Default = true
+		arg = strings.TrimPrefix(arg, defaultPrefix)
+	}
+
+	if strings.HasPrefix(arg, requiredPrefix) {
+		ad.Required = true
+		arg = strings.TrimPrefix(arg, requiredPrefix)
+	}
+
+	if strings.HasSuffix(arg, multipleSuffix) {
+		ad.Multiple = true
+		arg = strings.TrimSuffix(arg, multipleSuffix)
+	}
+
+	ad.Token = arg
+	ad.Hint = fmt.Sprintf("%s hint", arg)
+	ad.Desc = fmt.Sprintf("%s description", arg)
+
+	return ad
+}
+
+func genFlag(flag string) *FlagDefinition {
+	return &FlagDefinition{
+		CommonDefinition: CommonDefinition{
+			Token: flag,
+			Hint:  fmt.Sprintf("%s hint", flag),
+			Desc:  fmt.Sprintf("%s description", flag),
+		},
+	}
+}

--- a/internal/generate_test.go
+++ b/internal/generate_test.go
@@ -1,0 +1,73 @@
+package internal
+
+import "testing"
+
+func TestGenCommand(t *testing.T) {
+	tests := []string{"", "c1"}
+	for _, tt := range tests {
+		t.Run(tt, func(t *testing.T) {
+			cmd := genCommand(tt)
+			assertValEquals(t, cmd.Token, tt)
+		})
+	}
+}
+
+func TestGenFlags(t *testing.T) {
+	tests := []string{"", "f1"}
+	for _, tt := range tests {
+		t.Run(tt, func(t *testing.T) {
+			flg := genFlag(tt)
+			assertValEquals(t, flg.Token, tt)
+		})
+	}
+}
+
+func TestGenArgument(t *testing.T) {
+	tests := []struct {
+		input string
+		token string
+		def   bool
+		req   bool
+		mult  bool
+	}{
+		{"", "", false, false, false},
+		{"a1", "a1", false, false, false},
+		{"_a1", "a1", true, false, false},
+		{"_*a1", "a1", true, true, false},
+		{"*a1", "a1", false, true, false},
+		{"*_a1", "_a1", false, true, false},
+		{"a1...", "a1", false, false, true},
+		{"_a1...", "a1", true, false, true},
+		{"_*a1...", "a1", true, true, true},
+		{"*a1...", "a1", false, true, true},
+		{"*_a1...", "_a1", false, true, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			arg := genArgument(tt.input)
+			assertValEquals(t, arg.Token, tt.token)
+			assertValEquals(t, arg.Default, tt.def)
+			assertValEquals(t, arg.Required, tt.req)
+			assertValEquals(t, arg.Multiple, tt.mult)
+		})
+	}
+}
+
+func TestGenDefinitions(t *testing.T) {
+	tests := []struct {
+		app           string
+		cmd, arg, flg []string
+	}{
+		{"app", []string{"c1"}, []string{"a1", "a2"}, []string{"f1", "f2", "f3"}},
+		{"app", []string{"c1", "c2", "c3"}, []string{"a1"}, []string{"f1", "f2"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.app, func(t *testing.T) {
+			defs := GenDefinitions(tt.app, tt.cmd, tt.arg, tt.flg)
+			assertValEquals(t, defs.App, tt.app)
+			assertValEquals(t, len(defs.Commands), len(tt.cmd))
+			assertValEquals(t, len(defs.Arguments), len(tt.arg))
+			assertValEquals(t, len(defs.Flags), len(tt.flg))
+		})
+	}
+}

--- a/internal/help.go
+++ b/internal/help.go
@@ -158,7 +158,7 @@ func printAppUsage(defs *Definitions) {
 	if defs == nil {
 		return
 	}
-	fmt.Printf("Usage: %s command [<arguments [<values>]>] [<flags>]\n",
+	fmt.Printf("Usage: %s command [arguments [values]] [flags]\n",
 		defs.App)
 }
 


### PR DESCRIPTION
Generate command prints the JSON for provided app, commands, arguments and flags. It can be used to generate most of the clo.json definitions file or to generate parts of it.

App, Commands and Flags are setting tokens, hints and desc.
Arguments provides few shortcuts:
- values prefixed with _ would be Default
- values prefixed with * would be Required
- values suffixed with ... would be Multiple
NOTES: _ should come before * if both are specified, otherwise only * would be recognized. To use _ , * , ... you want to wrap attribute token in quotes (e.g. "_arg1..."). Argument token with those special prefixes and/or suffixes would be trimmed of prexies/suffixes before getting assigned as an argument token.